### PR TITLE
instances for computation library with lazy import

### DIFF
--- a/src/SI_Toolkit/C_implementation/TF2C.py
+++ b/src/SI_Toolkit/C_implementation/TF2C.py
@@ -18,7 +18,9 @@ def tf2C(path_to_models, net_name, batch_size):
     )
 
     # Define input
-    input_data = np.array([[0.1, -0.123, 0.75, 0.54, -0.345, -1.0, -0.64]], dtype=np.float32)
+    input_length = len(net_info.inputs)
+    input_data = np.random.rand(1, input_length).astype(np.float32)
+
 
     # Define the target directory
     target_directory = os.path.join(path_to_models, net_name, 'C_implementation')

--- a/src/SI_Toolkit/Functions/General/Dataset.py
+++ b/src/SI_Toolkit/Functions/General/Dataset.py
@@ -184,8 +184,11 @@ class DatasetTemplate:
             self.scaling_tiv = self.scaling_tiv_epoch_factor * np.random.uniform(-2, 2, size=len(self.tiv))
             features[:, self.tiv_in_inputs_idx] +=  self.scaling_tiv[self.tiv_for_inputs_idx]
             targets[:, self.tiv_in_outputs_idx] += self.scaling_tiv[self.tiv_for_outputs_idx]
-
-
+        
+        # Add noise only to the last two columns of each row in features
+        noise_length = features.shape[1] - 45 # 45 is the number of columns that are waypoints without noise
+        features[:, -noise_length:] += np.random.normal(0, 0.005, features[:, -noise_length:].shape)
+            
         # If get_time_axis try to obtain a vector of time data for the chosen sample
         if get_time_axis:
             try:

--- a/src/SI_Toolkit/Functions/General/Normalising.py
+++ b/src/SI_Toolkit/Functions/General/Normalising.py
@@ -15,7 +15,7 @@ import os
 def get_normalization_function(
         normalization_info,
         variables_names,
-        lib=NumpyLibrary,
+        lib=NumpyLibrary(),
         normalization_type='minmax_sym',
         return_coeffs=False,
 ):

--- a/src/SI_Toolkit/Functions/TF/Compile.py
+++ b/src/SI_Toolkit/Functions/TF/Compile.py
@@ -3,7 +3,6 @@ import platform
 import os
 
 import tensorflow as tf
-import torch
 
 from SI_Toolkit.computation_library import ComputationLibrary
 

--- a/src/SI_Toolkit/Predictors/__init__.py
+++ b/src/SI_Toolkit/Predictors/__init__.py
@@ -1,11 +1,11 @@
 from SI_Toolkit.computation_library import NumpyLibrary, PyTorchLibrary, TensorFlowLibrary
-import tensorflow as tf
+# import tensorflow as tf
 import numpy as np
 
 from SI_Toolkit_ASF.ToolkitCustomization.predictors_customization import CONTROL_INPUTS, STATE_VARIABLES
 
 class template_predictor:
-    supported_computation_libraries: set = {NumpyLibrary, TensorFlowLibrary, PyTorchLibrary}
+    supported_computation_libraries = (NumpyLibrary, TensorFlowLibrary, PyTorchLibrary)
     
     def __init__(self, horizon: float, batch_size: int) -> None:
         self.horizon = horizon
@@ -19,7 +19,7 @@ class template_predictor:
         self.num_states = len(STATE_VARIABLES)
         self.num_control_inputs = len(CONTROL_INPUTS)
     
-    def predict_core(self, s: tf.Tensor, Q: tf.Tensor):
+    def predict_core(self, s: 'tf.Tensor', Q: 'tf.Tensor'):
         """Predict the whole MPC horizon using tensorflow
 
         :param s: Initial state [batch_size x state_dim]

--- a/src/SI_Toolkit/Predictors/autoregression.py
+++ b/src/SI_Toolkit/Predictors/autoregression.py
@@ -26,7 +26,7 @@ class autoregression_loop:
         self.batch_size = batch_size
 
 
-        if self.lib == TensorFlowLibrary:
+        if isinstance(self.lib, TensorFlowLibrary):
             from tensorflow import TensorArray
             self.TensorArray = TensorArray
 

--- a/src/SI_Toolkit/Predictors/neural_network_evaluator.py
+++ b/src/SI_Toolkit/Predictors/neural_network_evaluator.py
@@ -38,10 +38,10 @@ class neural_network_evaluator:
             self.net.compile()
         elif self.net_info.library == 'Pytorch':
             from SI_Toolkit.computation_library import PyTorchLibrary
-            self._computation_library = PyTorchLibrary
+            self._computation_library = PyTorchLibrary()
         elif self.net_info.library == 'TF':
             from SI_Toolkit.computation_library import TensorFlowLibrary
-            self._computation_library = TensorFlowLibrary
+            self._computation_library = TensorFlowLibrary()
 
         if self.lib.lib == 'Pytorch':
             from SI_Toolkit.Functions.Pytorch.Network import get_device

--- a/src/SI_Toolkit/Predictors/predictor_ODE.py
+++ b/src/SI_Toolkit/Predictors/predictor_ODE.py
@@ -21,12 +21,12 @@ class model_interface:
 
 
 class predictor_ODE(template_predictor):
-    supported_computation_libraries = {TensorFlowLibrary, PyTorchLibrary, NumpyLibrary}  # Overwrites default from parent
+    supported_computation_libraries = (TensorFlowLibrary, PyTorchLibrary, NumpyLibrary)  # Overwrites default from parent
     
     def __init__(self,
                  horizon: int,
                  dt: float,
-                 computation_library=TensorFlowLibrary,
+                 computation_library=TensorFlowLibrary(),
                  intermediate_steps=10,
                  disable_individual_compilation=False,
                  batch_size=1,

--- a/src/SI_Toolkit/Predictors/predictor_autoregressive_GP.py
+++ b/src/SI_Toolkit/Predictors/predictor_autoregressive_GP.py
@@ -22,7 +22,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Restrict printing messages from TF
 
 
 class predictor_autoregressive_GP(template_predictor):
-    supported_computation_libraries = {TensorFlowLibrary}  # Overwrites default from parent
+    supported_computation_libraries = (TensorFlowLibrary)  # Overwrites default from parent
     
     def __init__(self,
                  model_name=None,

--- a/src/SI_Toolkit/Predictors/predictor_autoregressive_neural.py
+++ b/src/SI_Toolkit/Predictors/predictor_autoregressive_neural.py
@@ -37,7 +37,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # Restrict printing messages from TF
 
 
 class predictor_autoregressive_neural(template_predictor):
-    supported_computation_libraries = {TensorFlowLibrary, PyTorchLibrary, NumpyLibrary}  # Overwrites default from parent
+    supported_computation_libraries = (TensorFlowLibrary, PyTorchLibrary, NumpyLibrary)  # Overwrites default from parent
     # Numpy library is supported only when it comes to evaluation of hls4ml models
 
     def __init__(

--- a/src/SI_Toolkit/Predictors/predictor_wrapper.py
+++ b/src/SI_Toolkit/Predictors/predictor_wrapper.py
@@ -77,7 +77,7 @@ class PredictorWrapper:
         elif self.predictor_type == 'ODE':
             from SI_Toolkit.Predictors.predictor_ODE import predictor_ODE
             if computation_library is None:  # TODO: Remove it after making sure that the predictor gets the right library everywhere it is used.
-                computation_library = TensorFlowLibrary
+                computation_library = TensorFlowLibrary()
             self.predictor = predictor_ODE(horizon=self.horizon, dt=dt, batch_size=self.batch_size, variable_parameters=variable_parameters, **self.predictor_config, **compile_standalone)
 
         else:
@@ -87,9 +87,8 @@ class PredictorWrapper:
         self.num_control_inputs = self.predictor.num_control_inputs
         
         # computation_library defaults to None. In that case, do not check for conformity.
-        if computation_library is not None and computation_library not in self.predictor.supported_computation_libraries:
-            raise ValueError(f"Predictor {self.predictor.__class__.__name__} does not support {computation_library.__name__}")
-
+        if not isinstance(computation_library, self.predictor.supported_computation_libraries):
+            raise ValueError(f"Predictor {self.predictor.__class__.__name__} does not support {computation_library.__class__}")
     def configure_with_compilation(self, batch_size, horizon, dt, predictor_specification=None, mode=None, hls=False):
         """
         To get max performance


### PR DESCRIPTION
To save time, computational power and ram (especially on Jetson) we should not import Tensorflow, Pytorch and NUmpy all the time.
I tried to isolate the libraries so that they are only imported if used.

In the new version of ComputationLibrary, an instance is needed.
